### PR TITLE
feat: adding the edit and delete functionality in the "Add Movie" form time slot

### DIFF
--- a/frontend/src/common/Header/Header.jsx
+++ b/frontend/src/common/Header/Header.jsx
@@ -25,6 +25,9 @@ import OndemandVideoOutlinedIcon from '@mui/icons-material/OndemandVideoOutlined
 import DescriptionOutlinedIcon from '@mui/icons-material/DescriptionOutlined';
 import AccessTimeOutlinedIcon from '@mui/icons-material/AccessTimeOutlined';
 import EventOutlinedIcon from '@mui/icons-material/EventOutlined';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
+import CheckIcon from '@mui/icons-material/Check';
 import EventBusyOutlinedIcon from '@mui/icons-material/EventBusyOutlined';
 import PersonOutlinedIcon from '@mui/icons-material/PersonOutlined';
 import LocationCityOutlinedIcon from '@mui/icons-material/LocationCityOutlined';
@@ -93,6 +96,8 @@ function Header() {
   const inputRef = useRef(null);
   const [openDrawer, setOpenDrawer] = useState(false); // Drawer state
   const [isPage1Valid, setIsPage1Valid] = useState(false);
+  const [editingIndex, setEditingIndex] = useState(null);
+  const [editedTime, setEditedTime] = useState('');
   const navigate = useNavigate();
   const steps = ['Movie Details', 'Schedule Details'];
   const toggleDrawer = () => {
@@ -366,6 +371,24 @@ function Header() {
 
   const handleNext = () => setPage(1);
   const handleBack = () => setPage(0);
+
+  const handleDeleteTimeSlot = (index) => {
+    const updatedSlots = movie.timeSlots.filter((_, i) => i !== index);
+    setMovie({ ...movie, timeSlots: updatedSlots }); // Update movie state
+  };
+
+  const handleEdit = (index, slot) => {
+    setEditingIndex(index);
+    setEditedTime(slot);
+  };
+
+  const handleSaveEdit = (index) => {
+    if (!editedTime) return; // Prevent empty values
+    const updatedSlots = [...movie.timeSlots];
+    updatedSlots[index] = editedTime;
+    setMovie({ ...movie, timeSlots: updatedSlots }); // Update movie state
+    setEditingIndex(null);
+  };
 
   return (
     <>
@@ -2098,12 +2121,52 @@ function Header() {
                     key={index}
                     sx={{
                       fontSize: '18px',
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 1,
+                      border: '1px solid #ccc',
+                      padding: '5px',
+                      borderRadius: '4px',
                     }}
                   >
-                    {slot}
+                    {editingIndex === index ? (
+                      <TextField
+                        size="small"
+                        type="time"
+                        value={editedTime}
+                        onChange={(e) => setEditedTime(e.target.value)}
+                        sx={{ maxWidth: '100px' }}
+                      />
+                    ) : (
+                      <span>{slot}</span>
+                    )}
+
+                    {editingIndex === index ? (
+                      <IconButton
+                        size="small"
+                        onClick={() => handleSaveEdit(index)}
+                      >
+                        <CheckIcon fontSize="small" color="success" />
+                      </IconButton>
+                    ) : (
+                      <IconButton
+                        size="small"
+                        onClick={() => handleEdit(index, slot)}
+                      >
+                        <EditIcon fontSize="small" />
+                      </IconButton>
+                    )}
+
+                    <IconButton
+                      size="small"
+                      onClick={() => handleDeleteTimeSlot(index)}
+                    >
+                      <DeleteIcon fontSize="small" color="error" />
+                    </IconButton>
                   </Box>
                 ))}
               </Box>
+
               <DialogActions>
                 <Button
                   onClick={handleCloseMovieDialog}


### PR DESCRIPTION
This PR enhances the "Add Movie" form by allowing users to edit or delete scheduled times after they have been added. Previously, users couldn't modify or remove incorrect times, which led to usability issues.

Changes Implemented: (#45)
✅ Added a small "Edit" button (✏️) next to each scheduled time, allowing users to modify the entered time.
✅ Added a small "Delete" button (🗑️) next to each scheduled time to remove incorrect entries.
✅ UI updates instantly when a time is edited or deleted.
✅ Improved user experience by preventing unnecessary form resubmissions.

How to Test:
Go to the "Add Movie" form.
Add multiple schedule times.
Click the "Edit" button next to any time, modify it, and confirm the change.
Click the "Delete" button to remove a specific time.
Ensure changes reflect correctly in the UI.

Video:

https://github.com/user-attachments/assets/80a389f8-c067-4334-ba90-acd7b8f20b9a


Request for Reward 🏆
As discussed, I would like to request my reward for successfully completing the last two issues. Please let me know the process for receiving it.